### PR TITLE
Fix bug with handling multiple files

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,12 @@ var filesize = require('filesize');
 var tempWrite = require('temp-write');
 var csv = require('csv');
 
-var header = []
-	, record = [];
-
 module.exports = function (options) {
 	return map(function (file, cb) {
+
+		var record = [];
+		var header = [];
+
 		if (file.isNull()) {
 			return cb(null, file);
 		}


### PR DESCRIPTION
When a gulp stream is invoked with multiple files, each csv parse run is run in parallel.  (Obviously, without real concurrency but the operations end up interleaving).

Since the record and header variables were defined at the module level, they were being written by all the various parse runs in an interleaved manner and saved across runs.  This lead to unpredictable results and and each of the parse runs ending up with many more objects than there were records in the original files.

Making those accumulator variables private means that each invocation of the main function is now fully disjoint data-wise... yielding the expected results.
